### PR TITLE
EventBus integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -307,6 +307,8 @@ dependencies {
 
     implementation Deps.google_material
 
+    implementation Deps.eventbus
+
     androidTestImplementation Deps.uiautomator
 
     androidTestImplementation Deps.espresso_core, {

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
@@ -179,7 +179,6 @@ open class BrowserActivity : AppCompatActivity() {
     fun handleEvent(event: BrowserFragment.MessageEvent) {
         // Display message to user via Toast pop-up
         Toast.makeText(this, event.message, Toast.LENGTH_SHORT).show()
-        // prevent event from re-delivering, like when leaving and coming back to app
-        EventBus.getDefault().removeStickyEvent(event)
+        // Do not remove sticky event, so it can be read later in other activities
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/BrowserActivity.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
@@ -25,11 +26,14 @@ import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.webextensions.WebExtensionPopupFeature
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
 import org.mozilla.reference.browser.addons.WebExtensionActionPopupActivity
 import org.mozilla.reference.browser.browser.BrowserFragment
 import org.mozilla.reference.browser.browser.CrashIntegration
 import org.mozilla.reference.browser.ext.components
 import org.mozilla.reference.browser.ext.isCrashReportActive
+
 
 /**
  * Activity that holds the [BrowserFragment].
@@ -53,6 +57,16 @@ open class BrowserActivity : AppCompatActivity() {
      */
     open fun createBrowserFragment(sessionId: String?): Fragment =
         BrowserFragment.create(sessionId)
+
+    override fun onStart() {
+        super.onStart()
+        EventBus.getDefault().register(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        EventBus.getDefault().unregister(this)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -159,5 +173,13 @@ open class BrowserActivity : AppCompatActivity() {
         intent.putExtra("web_extension_name", webExtensionState.name)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)
+    }
+
+    @Subscribe(sticky = true)
+    fun handleEvent(event: BrowserFragment.MessageEvent) {
+        // Display message to user via Toast pop-up
+        Toast.makeText(this, event.message, Toast.LENGTH_SHORT).show()
+        // prevent event from re-delivering, like when leaving and coming back to app
+        EventBus.getDefault().removeStickyEvent(event)
     }
 }

--- a/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BrowserFragment.kt
@@ -146,4 +146,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             }
         }
     }
+
+    // Define message class for Eventbus
+    class MessageEvent(val message: String) {}
 }

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
@@ -37,6 +37,7 @@ import mozilla.components.lib.state.ext.flow
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.greenrobot.eventbus.EventBus
 import org.mozilla.reference.browser.R
 import org.mozilla.reference.browser.addons.AddonsActivity
 import org.mozilla.reference.browser.ext.components
@@ -60,6 +61,8 @@ class ToolbarIntegration(
     }
 
     private val scope = MainScope()
+
+    private val toastArray = context.resources.getStringArray(R.array.toasts_array)
 
     private fun menuToolbar(session: SessionState?): RowMenuCandidate {
         val tint = ContextCompat.getColor(context, R.color.icons)
@@ -171,6 +174,11 @@ class ToolbarIntegration(
                 val intent = Intent(context, SettingsActivity::class.java)
                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 context.startActivity(intent)
+            },
+
+            TextMenuCandidate(text = "Make a Toast") {
+                val message = toastArray.random()
+                EventBus.getDefault().postSticky(BrowserFragment.MessageEvent(message))
             }
         )
     }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -24,4 +24,5 @@
     <string name="pref_key_override_amo_collection" translatable="false">pref_key_override_amo_collection</string>
     <string name="pref_key_override_amo_user" translatable="false">pref_key_override_amo_user</string>
     <string name="pref_key_compose_ui" translatable="false">pref_key_compose_ui</string>
+    <string name="pref_key_read_toast" translatable="false">pref_key_read_toast</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,4 +198,54 @@
     <string name="customize_addon_collection_user_hint">Collection owner (User ID)</string>
     <!-- Toast shown after confirming the custom add-on collection configuration -->
     <string name="toast_customize_addon_collection_done">Add-on collection modified. Quitting the application to apply changes…</string>
+
+    <!-- "Cheers" in many different languages, source https://matadornetwork.com/nights/how-to-say-cheers-in-50-languages/ -->
+    <string-array name="toasts_array">
+        <item name="af">Gesondheid!</item>
+        <item name="ar">فى صحتك</item>
+        <item name="az">Nuş olsun!</item>
+        <item name="bg">Наздраве</item>
+        <item name="ca">Salut</item>
+        <item name="cy">Iechyd da</item>
+        <item name="el">ΥΓΕΙΑ</item>
+        <item name="es">¡Salude!</item>
+        <item name="en">Cheers!</item>
+        <item name="et">Terviseks!</item>
+        <item name="fr">Santé!</item>
+        <item name="fi">Kippis!</item>
+        <item name="de">Prost!</item>
+        <item name="da">Skål!</item>
+        <item name="hi">Å’kålè ma’luna</item>
+        <item name="hr">Živjeli!</item>
+        <item name="hu">Egészségedre</item>
+        <item name="hy">Կէնաձդ</item>
+        <item name="is">Skál</item>
+        <item name="it">Cin cin!</item>
+        <item name="iw">לחיים</item>
+        <item name="ga">Sláinte!</item>
+        <item name="gl">Salud</item>
+        <item name="gu">Biba</item>
+        <item name="ja">乾杯</item>
+        <item name="ji">Sei gesund</item>
+        <item name="ko">건배</item>
+        <item name="lv">Priekā</item>
+        <item name="lt">į sveikatą</item>
+        <item name="mk">На здравје</item>
+        <item name="mn">Эрүүл мэндийн төлөө</item>
+        <item name="my">Aung myin par say</item>
+        <item name="pl">Na zdrowie</item>
+        <item name="pt">Saúde</item>
+        <item name="ro">Noroc</item>
+        <item name="sl">Na zdravje</item>
+        <item name="sk">Na zdravie</item>
+        <item name="sr">živeli</item>
+        <item name="sq">Gëzuar</item>
+        <item name="th">Chok dee</item>
+        <item name="tl">Mabuhay</item>
+        <item name="tr">Şerefe</item>
+        <item name="uk">будьмо</item>
+        <item name="vi">Dô / Vô / Một hai ba, yo</item>
+        <item name="zh">干杯</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,8 @@
     <!-- Toast shown after confirming the custom add-on collection configuration -->
     <string name="toast_customize_addon_collection_done">Add-on collection modified. Quitting the application to apply changes…</string>
 
+    <string name="preferences_read_toast">Read most recent toast</string>
+
     <!-- "Cheers" in many different languages, source https://matadornetwork.com/nights/how-to-say-cheers-in-50-languages/ -->
     <string-array name="toasts_array">
         <item name="af">Gesondheid!</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -43,6 +43,10 @@
         android:defaultValue="false"
         android:title="@string/preferences_compose_ui"/>
 
+    <androidx.preference.Preference
+        android:key="@string/pref_key_read_toast"
+        android:title="@string/preferences_read_toast" />
+
     <PreferenceCategory
         android:title="@string/developer_tools_category">
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,6 +33,8 @@ private object Versions {
 
     const val compose_version = "1.0.0-rc02"
 
+    const val eventbus = "3.3.1"
+
     object AndroidX {
         const val activity_compose = "1.3.0-rc02"
         const val core = "1.1.0"
@@ -150,4 +152,5 @@ object Deps {
     const val tools_test_rules = "androidx.test:rules:${Versions.tools_test_rules}"
     const val tools_test_runner = "androidx.test:runner:${Versions.tools_test_runner}"
     const val uiautomator = "androidx.test.uiautomator:uiautomator:${Versions.uiautomator}"
+    const val eventbus = "org.greenrobot:eventbus:${Versions.eventbus}"
 }


### PR DESCRIPTION
This pull request integrates the [EventBus](https://github.com/greenrobot/EventBus) library as a dependency in the [Mozilla Reference Browser](https://github.com/mozilla-mobile/reference-browser) and provides an example of publishing a message and two options for reading the messages in different activities.

## Usage

After starting the reference browser, to publish a message on the EventBus, open the "three-dot menu" and select "Make a Toast". The text content of the message will be selected at random from a list of "Cheers!" in 45 different languages. In the BrowseActivity, which is setup as a subscriber to the EventBus, the message is immediately displayed as a toast pop-up.

Additionally, after publishing a message, it can be re-read in the Settings page. Choose the "Settings" option from the three-dot menu and select "Read most recent toast." The EventBus is limited in that only the most recent sticky post is available to be read. Once the most recent toast is read (or if no toast has been made), the "Read most recent toast" option is disabled.
